### PR TITLE
Add new similarity function: containment_max

### DIFF
--- a/SetSimilaritySearch/utils.py
+++ b/SetSimilaritySearch/utils.py
@@ -18,10 +18,10 @@ def _containment_overlap_threshold_func(x, t):
 def _containment_overlap_index_threshold_func(x, t):
     return 1
 
-def _containment_max_overlap_threshold_func(x, t):
+def _containment_min_overlap_threshold_func(x, t):
     return int(x * t)
 
-def _containment_max_overlap_index_threshold_func(x, t):
+def _containment_min_overlap_index_threshold_func(x, t):
     return int(x * t)
 
 def _jaccard_position_filter(s1, s2, p1, p2, t):
@@ -36,7 +36,7 @@ def _containment_position_filter(s1, s2, p1, p2, t):
     l1, l2 = len(s1), len(s2)
     return float(min(l1-p1, l2-p2)) / float(l1) >= t
 
-def _containment_max_position_filter(s1, s2, p1, p2, t):
+def _containment_min_position_filter(s1, s2, p1, p2, t):
     l1, l2 = len(s1), len(s2)
     return float(min(l1-p1, l2-p2)) / float(max(l1, l2)) >= t
 
@@ -52,7 +52,7 @@ def _containment(s1, s2):
     i = len(np.intersect1d(s1, s2, assume_unique=True))
     return float(i) / float(len(s1))
 
-def _containment_max(s1, s2):
+def _containment_min(s1, s2):
     i = len(np.intersect1d(s1, s2, assume_unique=True))
     return (float(i)) / (float(max(len(s1), len(s2))))
 
@@ -60,21 +60,21 @@ _similarity_funcs = {
     "jaccard": _jaccard,
     "cosine": _cosine,
     "containment": _containment,
-    "containment_max": _containment_max,
+    "containment_min": _containment_min,
 }
 
 _overlap_threshold_funcs = {
     "jaccard": _jaccard_overlap_threshold_func,
     "cosine": _cosine_overlap_threshold_func,
     "containment": _containment_overlap_threshold_func,
-    "containment_max": _containment_max_overlap_threshold_func,
+    "containment_min": _containment_min_overlap_threshold_func,
 }
 
 _overlap_index_threshold_funcs = {
     "jaccard": _jaccard_overlap_index_threshold_func,
     "cosine": _cosine_overlap_index_threshold_func,
     "containment": _containment_overlap_index_threshold_func,
-    "containment_max": _containment_max_overlap_index_threshold_func,
+    "containment_min": _containment_min_overlap_index_threshold_func,
 
 }
 
@@ -82,10 +82,10 @@ _position_filter_funcs = {
     "jaccard": _jaccard_position_filter,
     "cosine": _cosine_position_filter,
     "containment": _containment_position_filter,
-    "containment_max":  _containment_max_position_filter,
+    "containment_min":  _containment_min_position_filter,
 }
 
-_symmetric_similarity_funcs = ["jaccard", "cosine", "containment_max"]
+_symmetric_similarity_funcs = ["jaccard", "cosine", "containment_min"]
 _asymmetric_similarity_funcs = ["containment"]
 
 def _frequency_order_transform(sets):

--- a/SetSimilaritySearch/utils.py
+++ b/SetSimilaritySearch/utils.py
@@ -18,6 +18,12 @@ def _containment_overlap_threshold_func(x, t):
 def _containment_overlap_index_threshold_func(x, t):
     return 1
 
+def _containment_max_overlap_threshold_func(x, t):
+    return int(x * t)
+
+def _containment_max_overlap_index_threshold_func(x, t):
+    return int(x * t)
+
 def _jaccard_position_filter(s1, s2, p1, p2, t):
     l1, l2 = len(s1), len(s2)
     return float(min(l1-p1, l2-p2)) / float(max(l1, l2)) >= t
@@ -29,6 +35,10 @@ def _cosine_position_filter(s1, s2, p1, p2, t):
 def _containment_position_filter(s1, s2, p1, p2, t):
     l1, l2 = len(s1), len(s2)
     return float(min(l1-p1, l2-p2)) / float(l1) >= t
+
+def _containment_max_position_filter(s1, s2, p1, p2, t):
+    l1, l2 = len(s1), len(s2)
+    return float(min(l1-p1, l2-p2)) / float(max(l1, l2)) >= t
 
 def _jaccard(s1, s2):
     i = len(np.intersect1d(s1, s2, assume_unique=True))
@@ -42,31 +52,40 @@ def _containment(s1, s2):
     i = len(np.intersect1d(s1, s2, assume_unique=True))
     return float(i) / float(len(s1))
 
+def _containment_max(s1, s2):
+    i = len(np.intersect1d(s1, s2, assume_unique=True))
+    return (float(i)) / (float(max(len(s1), len(s2))))
+
 _similarity_funcs = {
     "jaccard": _jaccard,
     "cosine": _cosine,
     "containment": _containment,
+    "containment_max": _containment_max,
 }
 
 _overlap_threshold_funcs = {
     "jaccard": _jaccard_overlap_threshold_func,
     "cosine": _cosine_overlap_threshold_func,
     "containment": _containment_overlap_threshold_func,
+    "containment_max": _containment_max_overlap_threshold_func,
 }
 
 _overlap_index_threshold_funcs = {
     "jaccard": _jaccard_overlap_index_threshold_func,
     "cosine": _cosine_overlap_index_threshold_func,
     "containment": _containment_overlap_index_threshold_func,
+    "containment_max": _containment_max_overlap_index_threshold_func,
+
 }
 
 _position_filter_funcs = {
     "jaccard": _jaccard_position_filter,
     "cosine": _cosine_position_filter,
     "containment": _containment_position_filter,
+    "containment_max":  _containment_max_position_filter,
 }
 
-_symmetric_similarity_funcs = ["jaccard", "cosine"]
+_symmetric_similarity_funcs = ["jaccard", "cosine", "containment_max"]
 _asymmetric_similarity_funcs = ["containment"]
 
 def _frequency_order_transform(sets):


### PR DESCRIPTION
Based on  our communication via e-mail, I am adding a new similarity function "containment_max". This similarity function is similar to "containment", with the difference that the similarity value between two sets is normalised by the max. length of the two sets (instead of normalising it by the length of set1 as in "containment" function).