### PR TITLE
Allow input to be any iterable

### DIFF
--- a/SetSimilaritySearch/all_pairs.py
+++ b/SetSimilaritySearch/all_pairs.py
@@ -27,7 +27,7 @@ def all_pairs(sets, similarity_func_name="jaccard",
             where `x` and `y` are the indices of sets in the input list `sets`.
     """
     if not isinstance(sets, Iterable) or len(sets) == 0:
-        raise ValueError("Input parameter sets must be a non-empty list.")
+        raise ValueError("Input parameter sets must be a non-empty iterable.")
     if similarity_func_name not in _similarity_funcs:
         raise ValueError("Similarity function {} is not supported.".format(
             similarity_func_name))

--- a/SetSimilaritySearch/all_pairs.py
+++ b/SetSimilaritySearch/all_pairs.py
@@ -1,6 +1,7 @@
 import logging
 from collections import defaultdict
 import numpy as np
+from collections.abc import Iterable
 
 from SetSimilaritySearch.utils import _frequency_order_transform, \
         _similarity_funcs, _overlap_threshold_funcs, _position_filter_funcs, \
@@ -25,7 +26,7 @@ def all_pairs(sets, similarity_func_name="jaccard",
         pairs (Iterator[tuple]): an iterator of tuples `(x, y, similarity)`
             where `x` and `y` are the indices of sets in the input list `sets`.
     """
-    if not isinstance(sets, list) or len(sets) == 0:
+    if not isinstance(sets, Iterable) or len(sets) == 0:
         raise ValueError("Input parameter sets must be a non-empty list.")
     if similarity_func_name not in _similarity_funcs:
         raise ValueError("Similarity function {} is not supported.".format(

--- a/SetSimilaritySearch/search.py
+++ b/SetSimilaritySearch/search.py
@@ -1,6 +1,7 @@
 import logging
 from collections import defaultdict, deque
 import numpy as np
+from collections.abc import Iterable
 
 from SetSimilaritySearch.utils import _frequency_order_transform, \
         _similarity_funcs, _overlap_threshold_funcs, _position_filter_funcs, \
@@ -24,8 +25,8 @@ class SearchIndex(object):
 
     def __init__(self, sets, similarity_func_name="jaccard",
             similarity_threshold=0.5):
-        if not isinstance(sets, list) or len(sets) == 0:
-            raise ValueError("Input parameter sets must be a non-empty list.")
+        if not isinstance(sets, Iterable) or len(sets) == 0:
+            raise ValueError("Input parameter sets must be a non-empty iterable.")
         if similarity_func_name not in _similarity_funcs:
             raise ValueError("Similarity function {} is not supported.".format(
                 similarity_func_name))
@@ -89,4 +90,3 @@ class SearchIndex(object):
             results.append((i, sim))
         logging.debug("{} verified sets found.".format(len(results)))
         return list(results)
-

--- a/SetSimilaritySearch/search.py
+++ b/SetSimilaritySearch/search.py
@@ -90,3 +90,4 @@ class SearchIndex(object):
             results.append((i, sim))
         logging.debug("{} verified sets found.".format(len(results)))
         return list(results)
+


### PR DESCRIPTION
Closes #7 

Quoting from the issue:

> Currently
> 
> https://github.com/ekzhu/SetSimilaritySearch/blob/master/SetSimilaritySearch/search.py#L27
> https://github.com/ekzhu/SetSimilaritySearch/blob/master/SetSimilaritySearch/all_pairs.py#L28
> 
> state:
> 
> ```python
> if not isinstance(sets, list) or len(sets) == 0:
>         raise ValueError("Input parameter sets must be a non-empty list.")
> ```
> 
> I propose to change this to:
> ```python
> if not isinstance(sets, Iterable) or len(sets) == 0:
>         raise ValueError("Input parameter sets must be a non-empty iterable.")
> ```
> Which then allows inputs as tuple as well, as well as ordered key-sets. Was helpful in my use case, rather than having to create a copy of the data in list form.